### PR TITLE
Usage of TM_RUBY.

### DIFF
--- a/Commands/Minimize current file.tmCommand
+++ b/Commands/Minimize current file.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>"${TM_RUBY:-ruby}" "$TM_BUNDLE_SUPPORT/bin/jsmin.rb"</string>
+	<string>ruby "$TM_BUNDLE_SUPPORT/bin/jsmin.rb"</string>
 	<key>fallbackInput</key>
 	<string>scope</string>
 	<key>input</key>

--- a/Commands/Minimize selection.tmCommand
+++ b/Commands/Minimize selection.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>"${TM_RUBY:-ruby}" -e 'print `ruby "$TM_BUNDLE_SUPPORT/bin/jsmin.rb"`[1..-1]'</string>
+	<string>ruby -e 'print `ruby "$TM_BUNDLE_SUPPORT/bin/jsmin.rb"`[1..-1]'</string>
 	<key>fallbackInput</key>
 	<string>scope</string>
 	<key>input</key>

--- a/Commands/Packr.tmCommand
+++ b/Commands/Packr.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>"${TM_RUBY:-ruby}" "$TM_BUNDLE_SUPPORT/bin/compress_dean_edwards.rb"</string>
+	<string>ruby "$TM_BUNDLE_SUPPORT/bin/compress_dean_edwards.rb"</string>
 	<key>fallbackInput</key>
 	<string>scope</string>
 	<key>input</key>

--- a/Commands/Quick Lint.tmCommand
+++ b/Commands/Quick Lint.tmCommand
@@ -6,7 +6,7 @@
 	<string>saveActiveFile</string>
 	<key>command</key>
 	<string># runs on save; only notifies you if it raises a warning or error
-"${TM_RUBY:-ruby}" "$TM_BUNDLE_SUPPORT/bin/quick_lint.rb"</string>
+ruby "$TM_BUNDLE_SUPPORT/bin/quick_lint.rb"</string>
 	<key>input</key>
 	<string>none</string>
 	<key>keyEquivalent</key>

--- a/Commands/Run JavaScript Lint on current file.tmCommand
+++ b/Commands/Run JavaScript Lint on current file.tmCommand
@@ -7,7 +7,7 @@
 	<key>command</key>
 	<string>. "$TM_SUPPORT_PATH/lib/webpreview.sh"
 html_header "Validate Javascript"
-"${TM_RUBY:-ruby}" "$TM_BUNDLE_SUPPORT/bin/lint.rb"
+ruby "$TM_BUNDLE_SUPPORT/bin/lint.rb"
 html_footer
 </string>
 	<key>fallbackInput</key>

--- a/Commands/Validate with Google Closure Compiler.tmCommand
+++ b/Commands/Validate with Google Closure Compiler.tmCommand
@@ -7,7 +7,7 @@
 	<key>command</key>
 	<string>. "$TM_SUPPORT_PATH/lib/webpreview.sh"
 html_header "Validate Javascript"
-"${TM_RUBY:-ruby}" "$TM_BUNDLE_SUPPORT/bin/lint-gcc.rb"
+ruby "$TM_BUNDLE_SUPPORT/bin/lint-gcc.rb"
 html_footer
 </string>
 	<key>fallbackInput</key>


### PR DESCRIPTION
Going through and removing all the usage of TM_RUBY outside of the Ruby/etc bundle in favor of using the built-in system-supplied ruby.
